### PR TITLE
Prmt 2773 use new message ids bugfix

### DIFF
--- a/src/__tests__/app.integration.test.js
+++ b/src/__tests__/app.integration.test.js
@@ -342,7 +342,6 @@ describe('Ensure health record outbound XML is unchanged', () => {
       .sort()
 
     expect(sendFragment).toBeCalledTimes(4);
-
     expect(validateMessageEquality(originalFragments[0], receivedArguments[0])).toBe(true);
     expect(validateMessageEquality(originalFragments[1], receivedArguments[1])).toBe(true);
     expect(validateMessageEquality(originalFragments[2], receivedArguments[2])).toBe(true);

--- a/src/__tests__/message-id.integration.test.js
+++ b/src/__tests__/message-id.integration.test.js
@@ -97,6 +97,7 @@ describe('Replacement of message IDs', () => {
       const ebXML = JSON.parse(ehrCore).ebXML;
       const oldMessageId = await extractMessageId(ebXML);
       const oldReferencedFragmentIds = await extractReferencedFragmentMessageIds(ebXML);
+      const uuidRegexPattern = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/
 
       // set up mocks
       const ehrRepoScope = setUpMockForEhrRepoCoreMessage();
@@ -126,7 +127,8 @@ describe('Replacement of message IDs', () => {
         conversationId: conversationId,
         odsCode: odsCode,
         ehrRequestId: ehrRequestId,
-        coreEhr: expect.anything()
+        coreEhr: expect.anything(),
+        messageId: expect.stringMatching(uuidRegexPattern)
       });
 
       const outBoundEhrCore = gp2gpMessengerPostBody.coreEhr;

--- a/src/services/gp2gp/__tests__/send-core.test.js
+++ b/src/services/gp2gp/__tests__/send-core.test.js
@@ -27,11 +27,13 @@ describe('sendCore', () => {
   const ODS_CODE = 'G67200';
   const CORE_EHR = { ebXML: "", payload: "", attachments: [] };
   const EHR_REQUEST_ID = '5cefa7a2-fbca-494a-a114-6f58fae4be4a';
+  const MESSAGE_ID = '242d2dfa-9972-4798-8397-86a046f98e1d';
   const REQUEST_BODY = {
     conversationId: CONVERSATION_ID,
     odsCode: ODS_CODE,
     coreEhr: CORE_EHR,
-    ehrRequestId: EHR_REQUEST_ID
+    ehrRequestId: EHR_REQUEST_ID,
+    messageId: MESSAGE_ID
   };
   const HEADERS = { reqheaders: { Authorization: AUTH_KEYS } };
   // =================== END ===================
@@ -39,10 +41,10 @@ describe('sendCore', () => {
   it('should log message if ehr core sent successfully', async () => {
     // when
     const mockUrlRequest = nock(REQUEST_BASE_URL, HEADERS)
-      .post(`${REQUEST_ENDPOINT}/core`)
+      .post(`${REQUEST_ENDPOINT}/core`, REQUEST_BODY)
       .reply(204);
 
-    await sendCore(CONVERSATION_ID, ODS_CODE, CORE_EHR, EHR_REQUEST_ID);
+    await sendCore(CONVERSATION_ID, ODS_CODE, CORE_EHR, EHR_REQUEST_ID, MESSAGE_ID);
 
     // then
     expect(mockUrlRequest.isDone()).toBe(true);
@@ -53,11 +55,11 @@ describe('sendCore', () => {
   it('should throw error if sending ehr core unsuccessful', async () => {
     // when
     const mockUrlRequest = nock(REQUEST_BASE_URL, HEADERS)
-      .post(`${REQUEST_ENDPOINT}/fragment`)
+      .post(`${REQUEST_ENDPOINT}/core`)
       .reply(404);
 
     // then
-    await expect(() => sendCore(CONVERSATION_ID, ODS_CODE, CORE_EHR, EHR_REQUEST_ID))
+    await expect(() => sendCore(CONVERSATION_ID, ODS_CODE, CORE_EHR, EHR_REQUEST_ID, MESSAGE_ID))
       .rejects
       .toThrowError(SendCoreError);
   });

--- a/src/services/gp2gp/send-core.js
+++ b/src/services/gp2gp/send-core.js
@@ -3,11 +3,11 @@ import { logInfo, logError } from '../../middleware/logging';
 import { config } from '../../config';
 import { SendCoreError } from "../../errors/errors";
 
-export const sendCore = async (conversationId, odsCode, coreEhr, ehrRequestId) => {
+export const sendCore = async (conversationId, odsCode, coreEhr, ehrRequestId, newMessageId) => {
   const { gp2gpMessengerServiceUrl, gp2gpMessengerAuthKeys } = config();
   const url = `${gp2gpMessengerServiceUrl}/ehr-out-transfers/core`;
 
-  const requestBody = { conversationId, odsCode, coreEhr, ehrRequestId };
+  const requestBody = { conversationId, odsCode, coreEhr, ehrRequestId, messageId: newMessageId };
 
   await axios.post(url, requestBody, { headers: { Authorization: gp2gpMessengerAuthKeys } })
     .then(() => logInfo('Successfully sent ehr core'))

--- a/src/services/transfer/__tests__/transfer-out-ehr-core.test.js
+++ b/src/services/transfer/__tests__/transfer-out-ehr-core.test.js
@@ -5,6 +5,7 @@ import { transferOutEhrCore } from '../transfer-out-ehr-core';
 import { getEhrCoreAndFragmentIdsFromRepo } from '../../ehr-repo/get-ehr';
 import { createRegistrationRequest } from '../../database/create-registration-request';
 import expect from 'expect';
+import { v4 as uuid } from 'uuid';
 import { sendCore } from '../../gp2gp/send-core';
 import {
   EhrUrlNotFoundError,
@@ -128,9 +129,10 @@ describe('transferOutEhrCore', () => {
 
   it('should replace the main message ID in ehr core before sending out, if no fragment', async () => {
     // given
+    const newMessageId = uuid();
     getRegistrationRequestStatusByConversationId.mockResolvedValueOnce(null);
     getEhrCoreAndFragmentIdsFromRepo.mockResolvedValueOnce({ ehrCore, fragmentMessageIds: [] });
-    updateMessageIdForEhrCore.mockResolvedValueOnce(ehrCoreWithUpdatedMessageId);
+    updateMessageIdForEhrCore.mockResolvedValueOnce({ehrCoreWithUpdatedMessageId, newMessageId});
 
     // when
     const result = await transferOutEhrCore({ conversationId, nhsNumber, odsCode, ehrRequestId });
@@ -141,7 +143,8 @@ describe('transferOutEhrCore', () => {
       conversationId,
       odsCode,
       ehrCoreWithUpdatedMessageId,
-      ehrRequestId
+      ehrRequestId,
+      newMessageId
     );
     expect(result).toEqual({ hasFailed: false, inProgress: false });
 
@@ -151,8 +154,10 @@ describe('transferOutEhrCore', () => {
 
   it('should create new message ids for fragment and replace them in ehrCore, if fragment is referenced', async () => {
     // given
+    const newMessageId = uuid();
     getRegistrationRequestStatusByConversationId.mockResolvedValueOnce(null);
     getEhrCoreAndFragmentIdsFromRepo.mockResolvedValueOnce({ ehrCore, fragmentMessageIds });
+    updateMessageIdForEhrCore.mockResolvedValueOnce({ ehrCoreWithUpdatedMessageId, newMessageId });
     updateReferencedFragmentIds.mockResolvedValueOnce(
       ehrCoreWithUpdatedReferencedFragmentMessageId
     );
@@ -167,14 +172,17 @@ describe('transferOutEhrCore', () => {
       conversationId,
       odsCode,
       ehrCoreWithUpdatedReferencedFragmentMessageId,
-      ehrRequestId
+      ehrRequestId,
+      newMessageId
     );
     expect(result).toEqual({ hasFailed: false, inProgress: false });
   });
 
   it('should send EHR core on success', async () => {
+    const newMessageId = uuid();
     getRegistrationRequestStatusByConversationId.mockResolvedValueOnce(null);
     getEhrCoreAndFragmentIdsFromRepo.mockResolvedValueOnce({ ehrCore });
+    updateMessageIdForEhrCore.mockResolvedValueOnce({ ehrCoreWithUpdatedMessageId, newMessageId });
 
     const result = await transferOutEhrCore({ conversationId, nhsNumber, odsCode, ehrRequestId });
 
@@ -196,7 +204,8 @@ describe('transferOutEhrCore', () => {
       conversationId,
       odsCode,
       ehrCoreWithUpdatedMessageId,
-      ehrRequestId
+      ehrRequestId,
+      newMessageId
     );
   });
 

--- a/src/services/transfer/__tests__/transfer-out-ehr-core.test.js
+++ b/src/services/transfer/__tests__/transfer-out-ehr-core.test.js
@@ -33,6 +33,7 @@ jest.mock('../transfer-out-util');
 describe('transferOutEhrCore', () => {
   const conversationId = '5bb36755-279f-43d5-86ab-defea717d93f';
   const ehrRequestId = '870f6ef9-746f-4e81-b51f-884d64530bed';
+  const newMessageId = uuid();
   const odsCode = 'A12345';
   const nhsNumber = '1111111111';
   const ehrCore = {
@@ -129,7 +130,6 @@ describe('transferOutEhrCore', () => {
 
   it('should replace the main message ID in ehr core before sending out, if no fragment', async () => {
     // given
-    const newMessageId = uuid();
     getRegistrationRequestStatusByConversationId.mockResolvedValueOnce(null);
     getEhrCoreAndFragmentIdsFromRepo.mockResolvedValueOnce({ ehrCore, fragmentMessageIds: [] });
     updateMessageIdForEhrCore.mockResolvedValueOnce({ehrCoreWithUpdatedMessageId, newMessageId});
@@ -154,7 +154,6 @@ describe('transferOutEhrCore', () => {
 
   it('should create new message ids for fragment and replace them in ehrCore, if fragment is referenced', async () => {
     // given
-    const newMessageId = uuid();
     getRegistrationRequestStatusByConversationId.mockResolvedValueOnce(null);
     getEhrCoreAndFragmentIdsFromRepo.mockResolvedValueOnce({ ehrCore, fragmentMessageIds });
     updateMessageIdForEhrCore.mockResolvedValueOnce({ ehrCoreWithUpdatedMessageId, newMessageId });
@@ -179,7 +178,6 @@ describe('transferOutEhrCore', () => {
   });
 
   it('should send EHR core on success', async () => {
-    const newMessageId = uuid();
     getRegistrationRequestStatusByConversationId.mockResolvedValueOnce(null);
     getEhrCoreAndFragmentIdsFromRepo.mockResolvedValueOnce({ ehrCore });
     updateMessageIdForEhrCore.mockResolvedValueOnce({ ehrCoreWithUpdatedMessageId, newMessageId });

--- a/src/services/transfer/__tests__/transfer-out-util.test.js
+++ b/src/services/transfer/__tests__/transfer-out-util.test.js
@@ -240,15 +240,17 @@ describe('testTransferOutUtil', () => {
       const ehrCore = JSON.parse(getValidEhrCore());
 
       // when
-      const ehrCoreWithUpdatedMessageId = await updateMessageIdForEhrCore(ehrCore);
+      const { ehrCoreWithUpdatedMessageId, newMessageId } = await updateMessageIdForEhrCore(ehrCore);
 
       // then
       const { messageId: oldMessageId } = await extractEbXmlData(ehrCore.ebXML);
-      const { messageId: newMessageId } = await extractEbXmlData(ehrCoreWithUpdatedMessageId.ebXML);
+      const { messageId: actualNewMessageId } = await extractEbXmlData(ehrCoreWithUpdatedMessageId.ebXML);
 
-      expect(newMessageId).not.toEqual(oldMessageId);
-      expect(uuidValidate(newMessageId)).toBe(true);
-      expect(newMessageId).toEqual(newMessageId.toUpperCase());
+      expect(actualNewMessageId).toEqual(newMessageId);
+      expect(actualNewMessageId).not.toEqual(oldMessageId);
+      expect(uuidValidate(actualNewMessageId)).toBe(true);
+      expect(actualNewMessageId).toEqual(actualNewMessageId.toUpperCase());
+
     });
 
     it('should throw an error when given an invalid ehrCore', async () => {

--- a/src/services/transfer/transfer-out-ehr-core.js
+++ b/src/services/transfer/transfer-out-ehr-core.js
@@ -49,7 +49,7 @@ export async function transferOutEhrCore({ conversationId, nhsNumber, odsCode, e
 
     await updateConversationStatus(conversationId, Status.ODS_VALIDATION_CHECKS_PASSED);
 
-    let ehrCoreWithUpdatedMessageId = await updateMessageIdForEhrCore(ehrCore);
+    let { ehrCoreWithUpdatedMessageId, newMessageId } = await updateMessageIdForEhrCore(ehrCore);
     logInfo(`Successfully replaced message id for ehrCore`);
 
     if (fragmentMessageIds?.length > 0) {
@@ -60,7 +60,7 @@ export async function transferOutEhrCore({ conversationId, nhsNumber, odsCode, e
     }
 
     logInfo('Sending EHR core');
-    await sendCore(conversationId, odsCode, ehrCoreWithUpdatedMessageId, ehrRequestId);
+    await sendCore(conversationId, odsCode, ehrCoreWithUpdatedMessageId, ehrRequestId, newMessageId);
 
     await updateConversationStatus(conversationId, Status.SENT_EHR, logs);
     return defaultResult;

--- a/src/services/transfer/transfer-out-util.js
+++ b/src/services/transfer/transfer-out-util.js
@@ -66,8 +66,11 @@ export const updateMessageIdForEhrCore = async ehrCore => {
     const { messageId } = await extractEbXmlData(ehrCore.ebXML);
 
     const newMessageId = uuidv4().toUpperCase();
+    const ehrCoreWithUpdatedMessageId = replaceMessageIdInObject(ehrCore, messageId, newMessageId);
 
-    return replaceMessageIdInObject(ehrCore, messageId, newMessageId);
+    return {
+      newMessageId, ehrCoreWithUpdatedMessageId
+    }
   } catch (error) {
     throw new MessageIdUpdateError(error);
   }


### PR DESCRIPTION
- Add the new messageId to the post request body of sendCore, as now GP2GP messenger expects to get the new messageId from ehr-out