### PR TITLE
PRMT-3545

### DIFF
--- a/src/__tests__/app.integration.test.js
+++ b/src/__tests__/app.integration.test.js
@@ -211,15 +211,17 @@ describe('Ensure health record outbound XML is unchanged', () => {
     // given
     const originalEhrCore = readFile('RCMR_IN030000UK06', 'equality-test', 'small-ehr', 'original');
     const ehrCoreAndFragmentIds = { ehrCore: JSON.parse(originalEhrCore), fragmentMessageIds: []};
+    const messageId = '4aa69fd3-6aaf-4f51-98ef-58a342c3265f';
 
     // when
-    getEhrCoreAndFragmentIdsFromRepo.mockReturnValueOnce(Promise.resolve(ehrCoreAndFragmentIds));
-    patientAndPracticeOdsCodesMatch.mockReturnValue(Promise.resolve(true));
-    sendCore.mockReturnValueOnce(Promise.resolve(undefined));
+    getEhrCoreAndFragmentIdsFromRepo.mockReturnValueOnce(ehrCoreAndFragmentIds);
+    patientAndPracticeOdsCodesMatch.mockReturnValue(true);
+    sendCore.mockReturnValueOnce(undefined);
 
     await transferOutEhrCore({
       conversationId: outboundConversationId,
       nhsNumber: nhsNumber,
+      messageId,
       odsCode: odsCode,
       ehrRequestId: ehrRequestMessageId
     });
@@ -229,6 +231,29 @@ describe('Ensure health record outbound XML is unchanged', () => {
     // then
     expect(validateMessageEquality(originalEhrCore, modifiedEhrCore)).toBe(true);
   });
+
+  // it('should verify that a small EHR core is unchanged by XML changes', async () => {
+  //   // given
+  //   const originalEhrCore = readFile('RCMR_IN030000UK06', 'equality-test', 'small-ehr', 'original');
+  //   const ehrCoreAndFragmentIds = { ehrCore: JSON.parse(originalEhrCore), fragmentMessageIds: []};
+  //
+  //   // when
+  //   getEhrCoreAndFragmentIdsFromRepo.mockReturnValueOnce(Promise.resolve(ehrCoreAndFragmentIds));
+  //   patientAndPracticeOdsCodesMatch.mockReturnValue(Promise.resolve(true));
+  //   sendCore.mockReturnValueOnce(Promise.resolve(undefined));
+  //
+  //   await transferOutEhrCore({
+  //     conversationId: outboundConversationId,
+  //     nhsNumber: nhsNumber,
+  //     odsCode: odsCode,
+  //     ehrRequestId: ehrRequestMessageId
+  //   });
+  //
+  //   const modifiedEhrCore = JSON.stringify(sendCore.mock.calls[0][2]);
+  //
+  //   // then
+  //   expect(validateMessageEquality(originalEhrCore, modifiedEhrCore)).toBe(true);
+  // });
 
   it('should verify that a fragment with no external attachments is unchanged by xml changes', async () => {
     // when

--- a/src/__tests__/app.integration.test.js
+++ b/src/__tests__/app.integration.test.js
@@ -232,29 +232,6 @@ describe('Ensure health record outbound XML is unchanged', () => {
     expect(validateMessageEquality(originalEhrCore, modifiedEhrCore)).toBe(true);
   });
 
-  // it('should verify that a small EHR core is unchanged by XML changes', async () => {
-  //   // given
-  //   const originalEhrCore = readFile('RCMR_IN030000UK06', 'equality-test', 'small-ehr', 'original');
-  //   const ehrCoreAndFragmentIds = { ehrCore: JSON.parse(originalEhrCore), fragmentMessageIds: []};
-  //
-  //   // when
-  //   getEhrCoreAndFragmentIdsFromRepo.mockReturnValueOnce(Promise.resolve(ehrCoreAndFragmentIds));
-  //   patientAndPracticeOdsCodesMatch.mockReturnValue(Promise.resolve(true));
-  //   sendCore.mockReturnValueOnce(Promise.resolve(undefined));
-  //
-  //   await transferOutEhrCore({
-  //     conversationId: outboundConversationId,
-  //     nhsNumber: nhsNumber,
-  //     odsCode: odsCode,
-  //     ehrRequestId: ehrRequestMessageId
-  //   });
-  //
-  //   const modifiedEhrCore = JSON.stringify(sendCore.mock.calls[0][2]);
-  //
-  //   // then
-  //   expect(validateMessageEquality(originalEhrCore, modifiedEhrCore)).toBe(true);
-  // });
-
   it('should verify that a fragment with no external attachments is unchanged by xml changes', async () => {
     // when
     await createRegistrationRequest(

--- a/src/services/database/__tests__/registration-request-repository.integration.test.js
+++ b/src/services/database/__tests__/registration-request-repository.integration.test.js
@@ -3,7 +3,7 @@ import { modelName, Status } from '../../../models/registration-request';
 import { NhsNumberNotFoundError } from "../../../errors/errors";
 import {
   getNhsNumberByConversationId,
-  getRegistrationRequestStatusByConversationId, registrationRequestExistsWithMessageId,
+  getRegistrationRequestStatusByConversationId, registrationRequestExistsWithMessageId, updateMessageId,
   updateRegistrationRequestStatus
 } from '../registration-request-repository';
 import ModelFactory from '../../../models';
@@ -68,6 +68,28 @@ describe('Registration request repository', () => {
 
     // then
     expect(registrationRequest.status).toBe(status);
+  });
+
+  it('should update the message id successfully', async () => {
+    // given
+    const conversationId = 'e7a1b0ea-c51d-499e-a25a-d155b6df9904';
+    const inboundMessageId = '0d3ff0e6-27a1-4e98-a3e8-ac67c930df5e';
+    const outboundMessageId = '37bfaf7e-cfe2-4300-8804-a6629f8db1fc';
+    const odsCode = 'B23456';
+    const nhsNumber = '1478541274';
+    const status = Status.REGISTRATION_REQUEST_RECEIVED;
+
+    // when
+    await createRegistrationRequest(conversationId, inboundMessageId, nhsNumber, odsCode);
+    await updateMessageId(inboundMessageId, outboundMessageId);
+    const registrationRequest = await getRegistrationRequestStatusByConversationId(conversationId);
+
+    // then
+    expect(registrationRequest.nhsNumber).toBe(nhsNumber);
+    expect(registrationRequest.status).toBe(status);
+    expect(registrationRequest.odsCode).toBe(odsCode);
+    expect(registrationRequest.conversationId).toBe(conversationId);
+    expect(registrationRequest.messageId).toBe(outboundMessageId);
   });
 
   describe('getNhsNumberByConversationId', () => {

--- a/src/services/database/__tests__/registration-request-repository.integration.test.js
+++ b/src/services/database/__tests__/registration-request-repository.integration.test.js
@@ -3,7 +3,7 @@ import { modelName, Status } from '../../../models/registration-request';
 import { NhsNumberNotFoundError } from "../../../errors/errors";
 import {
   getNhsNumberByConversationId,
-  getRegistrationRequestStatusByConversationId, registrationRequestExistsWithMessageId, updateMessageId,
+  getRegistrationRequestStatusByConversationId, registrationRequestExistsWithMessageId, updateRegistrationRequestMessageId,
   updateRegistrationRequestStatus
 } from '../registration-request-repository';
 import ModelFactory from '../../../models';
@@ -81,7 +81,7 @@ describe('Registration request repository', () => {
 
     // when
     await createRegistrationRequest(conversationId, inboundMessageId, nhsNumber, odsCode);
-    await updateMessageId(inboundMessageId, outboundMessageId);
+    await updateRegistrationRequestMessageId(inboundMessageId, outboundMessageId);
     const registrationRequest = await getRegistrationRequestStatusByConversationId(conversationId);
 
     // then

--- a/src/services/database/registration-request-repository.js
+++ b/src/services/database/registration-request-repository.js
@@ -16,7 +16,7 @@ export const getNhsNumberByConversationId = conversationId => {
         if (!record) {
             throw new NhsNumberNotFoundError(`No record for NHS number related to conversation ID ${conversationId}`);
         }
-        return record.nhsNumber
+        return record.nhsNumber;
     });
 };
 
@@ -28,7 +28,19 @@ export const updateRegistrationRequestStatus = async (conversationId, status) =>
       transaction: transaction
     }
 
-    return await RegistrationRequest.update({ status }, options)
+    return await RegistrationRequest.update({ status }, options);
+  });
+};
+
+export const updateMessageId = async (messageId, newMessageId) => {
+  logInfo(`Updating Message ID from ${messageId}, to: ${newMessageId}`);
+  await runWithinTransaction(async transaction => {
+    const options = {
+      where: { message_id: messageId },
+      transaction: transaction
+    }
+
+    return await RegistrationRequest.update({ newMessageId }, options);
   });
 };
 

--- a/src/services/database/registration-request-repository.js
+++ b/src/services/database/registration-request-repository.js
@@ -32,15 +32,15 @@ export const updateRegistrationRequestStatus = async (conversationId, status) =>
   });
 };
 
-export const updateMessageId = async (messageId, newMessageId) => {
-  logInfo(`Updating Message ID from ${messageId}, to: ${newMessageId}`);
+export const updateMessageId = async (originalMessageId, updatedMessageId) => {
+  logInfo(`Updating Message ID from ${originalMessageId}, to: ${updatedMessageId}`);
   await runWithinTransaction(async transaction => {
     const options = {
-      where: { message_id: messageId },
+      where: { message_id: originalMessageId },
       transaction: transaction
     }
 
-    return await RegistrationRequest.update({ newMessageId }, options);
+    return await RegistrationRequest.update({ messageId: updatedMessageId }, options);
   });
 };
 

--- a/src/services/database/registration-request-repository.js
+++ b/src/services/database/registration-request-repository.js
@@ -32,7 +32,7 @@ export const updateRegistrationRequestStatus = async (conversationId, status) =>
   });
 };
 
-export const updateMessageId = async (originalMessageId, updatedMessageId) => {
+export const updateRegistrationRequestMessageId = async (originalMessageId, updatedMessageId) => {
   logInfo(`Updating Message ID from ${originalMessageId}, to: ${updatedMessageId}`);
   await runWithinTransaction(async transaction => {
     const options = {

--- a/src/services/transfer/__tests__/transfer-out-ehr-core.test.js
+++ b/src/services/transfer/__tests__/transfer-out-ehr-core.test.js
@@ -1,6 +1,6 @@
 import {
   getRegistrationRequestStatusByConversationId,
-  updateMessageId
+  updateRegistrationRequestMessageId
 } from '../../database/registration-request-repository';
 import { logError, logInfo } from '../../../middleware/logging';
 import { Status } from '../../../models/registration-request';
@@ -297,12 +297,12 @@ describe('transferOutEhrCore', () => {
     getEhrCoreAndFragmentIdsFromRepo.mockResolvedValueOnce({ ehrCore, fragmentMessageIds: [] });
     getRegistrationRequestStatusByConversationId.mockResolvedValueOnce(null);
     updateMessageIdForEhrCore.mockResolvedValueOnce({ ehrCoreWithUpdatedMessageId, newMessageId });
-    updateMessageId.mockResolvedValue(undefined);
+    updateRegistrationRequestMessageId.mockResolvedValue(undefined);
     sendCore.mockResolvedValue(undefined);
 
     await transferOutEhrCore({ conversationId, nhsNumber, messageId, odsCode, ehrRequestId });
 
     // then
-    expect(updateMessageId).toBeCalledWith(messageId, newMessageId);
+    expect(updateRegistrationRequestMessageId).toBeCalledWith(messageId, newMessageId);
   });
 });

--- a/src/services/transfer/__tests__/transfer-out-ehr-core.test.js
+++ b/src/services/transfer/__tests__/transfer-out-ehr-core.test.js
@@ -94,7 +94,7 @@ describe('transferOutEhrCore', () => {
         conversationId,
         Status.MISSING_FROM_REPO
       );
-      expect(logInfo).toHaveBeenCalledWith(`Getting patient health record from EHR repo`);
+      expect(logInfo).toHaveBeenCalledWith(`Retrieving the patient's health record from the EHR Repository.`);
       expect(logError).toHaveBeenCalledWith(
         'EHR transfer out request failed',
         new EhrUrlNotFoundError()
@@ -123,7 +123,7 @@ describe('transferOutEhrCore', () => {
         conversationId,
         Status.EHR_DOWNLOAD_FAILED
       );
-      expect(logInfo).toHaveBeenCalledWith(`Getting patient health record from EHR repo`);
+      expect(logInfo).toHaveBeenCalledWith(`Retrieving the patient's health record from the EHR Repository.`);
       expect(logError).toHaveBeenCalledWith('EHR transfer out request failed', new DownloadError());
       expect(sendCore).not.toHaveBeenCalled();
     });
@@ -147,7 +147,7 @@ describe('transferOutEhrCore', () => {
       expect(updateConversationStatus).toHaveBeenCalledWith(
         conversationId,
         Status.INCORRECT_ODS_CODE,
-        `Patients ODS Code in PDS does not match requesting practices ODS Code`
+        `The patient's ODS Code in PDS does not match the requesting practice's ODS Code.`
       );
       expect(sendCore).not.toHaveBeenCalled();
     });
@@ -226,10 +226,10 @@ describe('transferOutEhrCore', () => {
     expect(updateConversationStatus).toHaveBeenCalledWith(
       conversationId,
       Status.SENT_EHR,
-      'EHR has been successfully sent'
+      'The EHR Core has successfully been sent.'
     );
-    expect(logInfo).toHaveBeenCalledWith('EHR transfer out started');
-    expect(logInfo).toHaveBeenCalledWith(`Sending EHR core`);
+    expect(logInfo).toHaveBeenCalledWith(`EHR Request received, transfer out process initiated for Outbound CID ${conversationId}.`);
+    expect(logInfo).toHaveBeenCalledWith(`Sending the EHR Core to GP2GP Messenger.`);
     expect(sendCore).toHaveBeenCalledWith(
       conversationId,
       odsCode,

--- a/src/services/transfer/transfer-out-ehr-core.js
+++ b/src/services/transfer/transfer-out-ehr-core.js
@@ -1,6 +1,6 @@
 import {
   getRegistrationRequestStatusByConversationId,
-  updateMessageId
+  updateRegistrationRequestMessageId
 } from '../database/registration-request-repository';
 import { logError, logInfo } from '../../middleware/logging';
 import { setCurrentSpanAttributes } from '../../config/tracing';
@@ -49,7 +49,7 @@ export async function transferOutEhrCore({
       conversationId
     );
 
-    await updateMessageId(messageId, newMessageId);
+    await updateRegistrationRequestMessageId(messageId, newMessageId);
 
     logInfo('Sending the EHR Core to GP2GP Messenger.');
 

--- a/src/services/transfer/transfer-out-ehr-core.js
+++ b/src/services/transfer/transfer-out-ehr-core.js
@@ -1,4 +1,7 @@
-import { getRegistrationRequestStatusByConversationId } from '../database/registration-request-repository';
+import {
+  getRegistrationRequestStatusByConversationId,
+  updateMessageId
+} from '../database/registration-request-repository';
 import { logError, logInfo } from '../../middleware/logging';
 import { setCurrentSpanAttributes } from '../../config/tracing';
 import { createRegistrationRequest } from '../database/create-registration-request';
@@ -50,6 +53,8 @@ export async function transferOutEhrCore({
       nhsNumber,
       conversationId
     );
+
+    await updateMessageId(messageId, newMessageId);
 
     logInfo('EHR transfer out started');
     logInfo('Sending EHR core');


### PR DESCRIPTION
- Added logic to update the `RegistrationRequest` message ID to use the `Outbound Message ID` over the `Inbound Message ID` , due to time constraints technical debt was logged to be addressed in a future ticket regarding cleaning up our databases.
- Added unit & integration tests.
- Fixed failing tests.