### PR TITLE
[PRMT-4063] Omitted `FRAGMENT_TRANSFER_RATE_LIMIT_TIMEOUT_MILLISECOND…

### DIFF
--- a/terraform/ecs_task.tf
+++ b/terraform/ecs_task.tf
@@ -26,8 +26,7 @@ locals {
     { name = "DB_SKIP_MIGRATION", value = "true" },
     { name = "USE_SSL_FOR_DB", value = "true" },
     { name = "LOG_LEVEL", value = var.log_level },
-    { name = "SQS_EHR_OUT_INCOMING_QUEUE_URL", value = aws_sqs_queue.service_incoming.id },
-    { name = "FRAGMENT_TRANSFER_RATE_LIMIT_TIMEOUT_MILLISECONDS", value = "100" }
+    { name = "SQS_EHR_OUT_INCOMING_QUEUE_URL", value = aws_sqs_queue.service_incoming.id }
   ]
   secret_environment_variables = [
     { name      = "GP2GP_MESSENGER_AUTHORIZATION_KEYS",


### PR DESCRIPTION
…S` - therefore defaulting to 0.