### PR TITLE
PRMT-4771

### DIFF
--- a/src/models/fragment.js
+++ b/src/models/fragment.js
@@ -6,10 +6,8 @@ import { validateIds } from '../utilities/validation-utilities';
 const fieldsAllowedToUpdate = [
   'TransferStatus',
   'FailureReason',
-  'OutboundMessageId',
-  'AcknowledgementReceivedAt',
-  'AcknowledgementTypeCode',
-  'AcknowledgementDetail'
+  'FailureCode',
+  'OutboundMessageId'
 ];
 
 export const buildFragmentUpdateParams = (inboundConversationId, inboundMessageId, changes) => {

--- a/src/services/database/dynamodb/__tests__/ehr-fragment-repository.integration.test.js
+++ b/src/services/database/dynamodb/__tests__/ehr-fragment-repository.integration.test.js
@@ -16,7 +16,6 @@ import { storeOutboundMessageIds } from '../store-outbound-message-ids';
 import { FailureReason, FragmentStatus, RecordType } from '../../../../constants/enums';
 import { logError, logInfo } from '../../../../middleware/logging';
 import { buildUpdateParamFromItem } from '../../../../utilities/dynamodb-helper';
-import { TIMESTAMP_REGEX } from '../../../time';
 
 jest.mock('../../../../middleware/logging');
 
@@ -204,6 +203,8 @@ describe('dynamodb-fragment-repository', () => {
       const acknowledgementDetail =
         'hl7:{interactionId}/hl7:communicationFunctionRcv/hl7:device/hl7:id/@extension is missing, empty, invalid or ACL violation';
       const acknowledgementTypeCode = 'AR';
+      const acknowledgementCode = 30;
+
       // given
       const parsedAcknowledgement = {
         service: 'urn:nhs:names:services:gp2gp',
@@ -211,7 +212,8 @@ describe('dynamodb-fragment-repository', () => {
         referencedMessageId: uuid().toUpperCase(),
         messageRef: outboundMessageIdOfFragment,
         acknowledgementTypeCode,
-        acknowledgementDetail
+        acknowledgementDetail,
+        acknowledgementCode
       };
 
       // when
@@ -228,9 +230,8 @@ describe('dynamodb-fragment-repository', () => {
         OutboundConversationId: OUTBOUND_CONVERSATION_ID,
         OutboundMessageId: outboundMessageIdOfFragment,
         InboundMessageId: inboundMessageIdOfFragment,
-        AcknowledgementTypeCode: acknowledgementTypeCode,
-        AcknowledgementDetail: acknowledgementDetail,
-        AcknowledgementReceivedAt: expect.stringMatching(TIMESTAMP_REGEX),
+        FailureCode: acknowledgementCode,
+        FailureReason: acknowledgementDetail,
         TransferStatus: FragmentStatus.OUTBOUND_FAILED
       });
 

--- a/src/services/database/dynamodb/ehr-fragment-repository.js
+++ b/src/services/database/dynamodb/ehr-fragment-repository.js
@@ -6,7 +6,6 @@ import {
 } from '../../../errors/errors';
 import { buildFragmentUpdateParams, isFragment, isNotSentOut } from '../../../models/fragment';
 import { FragmentStatus, RecordType } from '../../../constants/enums';
-import { getUKTimestamp } from '../../time';
 import { ACKNOWLEDGEMENT_TYPES } from '../../../constants/acknowledgement-types';
 
 export const getAllMessageIdPairs = async (oldMessageIds, inboundConversationId) => {
@@ -93,7 +92,7 @@ export const storeAcknowledgement = async (
   outboundConversationId
 ) => {
   try {
-    const { acknowledgementTypeCode, acknowledgementDetail, messageRef } =
+    const { acknowledgementCode, acknowledgementTypeCode, acknowledgementDetail, messageRef } =
       parsedAcknowledgementMessage;
     const db = EhrTransferTracker.getInstance();
     const allRecords = await db.queryTableByOutboundConversationId(outboundConversationId);
@@ -111,9 +110,8 @@ export const storeAcknowledgement = async (
     }
 
     const updateContent = {
-      AcknowledgementReceivedAt: getUKTimestamp(),
-      AcknowledgementTypeCode: acknowledgementTypeCode,
-      AcknowledgementDetail: acknowledgementDetail ?? null
+      FailureCode: acknowledgementCode,
+      FailureReason: acknowledgementDetail ?? null
     };
 
     if (ACKNOWLEDGEMENT_TYPES.POSITIVE.includes(acknowledgementTypeCode)) {

--- a/src/services/database/dynamodb/ehr-fragment-repository.js
+++ b/src/services/database/dynamodb/ehr-fragment-repository.js
@@ -110,7 +110,7 @@ export const storeAcknowledgement = async (
     }
 
     const updateContent = {
-      FailureCode: acknowledgementCode,
+      FailureCode: acknowledgementCode ?? null,
       FailureReason: acknowledgementDetail ?? null
     };
 

--- a/src/services/database/dynamodb/ehr-fragment-repository.js
+++ b/src/services/database/dynamodb/ehr-fragment-repository.js
@@ -110,8 +110,8 @@ export const storeAcknowledgement = async (
     }
 
     const updateContent = {
-      FailureCode: acknowledgementCode ?? null,
-      FailureReason: acknowledgementDetail ?? null
+      FailureCode: acknowledgementCode ?? undefined,
+      FailureReason: acknowledgementDetail ?? undefined
     };
 
     if (ACKNOWLEDGEMENT_TYPES.POSITIVE.includes(acknowledgementTypeCode)) {

--- a/src/services/parser/__test__/acknowledgement-parser.test.js
+++ b/src/services/parser/__test__/acknowledgement-parser.test.js
@@ -87,9 +87,9 @@ describe('parseCommonAcknowledgementFields', () => {
     const messageId = '3B768FD0-FECD-41ED-808B-AC162D1F16F0';
     const messageRef = '82BFE6C0-56CE-4466-886A-3FDE9D08D0C2';
     const referencedMessageId = 'NOT FOUND';
-    const acknowledgementDetail = 'NOT FOUND';
+    const acknowledgementDetail = undefined;
     const acknowledgementTypeCode = 'AA';
-    const acknowledgementCode = 'NOT FOUND';
+    const acknowledgementCode = undefined;
 
     // when
     validateFieldsHaveSuccessfullyParsed.mockReturnValueOnce(undefined);

--- a/src/services/parser/__test__/acknowledgement-parser.test.js
+++ b/src/services/parser/__test__/acknowledgement-parser.test.js
@@ -39,6 +39,7 @@ describe('parseCommonAcknowledgementFields', () => {
     const acknowledgementDetail =
       'hl7:{interactionId}/hl7:communicationFunctionRcv/hl7:device/hl7:id/@extension is missing, empty, invalid or ACL violation';
     const acknowledgementTypeCode = 'AR';
+    const acknowledgementCode = '506';
 
     // when
     validateFieldsHaveSuccessfullyParsed.mockReturnValueOnce(undefined);
@@ -51,6 +52,7 @@ describe('parseCommonAcknowledgementFields', () => {
     expect(parsedMessage.referencedMessageId).toEqual(referencedMessageId);
     expect(parsedMessage.acknowledgementDetail).toEqual(acknowledgementDetail);
     expect(parsedMessage.acknowledgementTypeCode).toEqual(acknowledgementTypeCode);
+    expect(parsedMessage.acknowledgementCode).toEqual(acknowledgementCode);
     expect(SERVICES.gp2gp).toEqual(parsedMessage.service);
     expect(ACKNOWLEDGEMENT_TYPES.NEGATIVE).toContain(parsedMessage.acknowledgementTypeCode);
   });
@@ -62,6 +64,7 @@ describe('parseCommonAcknowledgementFields', () => {
     const referencedMessageId = 'NOT FOUND';
     const acknowledgementDetail = 'Large Message general failure';
     const acknowledgementTypeCode = 'AR';
+    const acknowledgementCode = '30';
 
     // when
     validateFieldsHaveSuccessfullyParsed.mockReturnValueOnce(undefined);
@@ -74,6 +77,7 @@ describe('parseCommonAcknowledgementFields', () => {
     expect(parsedMessage.referencedMessageId).toEqual(referencedMessageId);
     expect(parsedMessage.acknowledgementDetail).toEqual(acknowledgementDetail);
     expect(parsedMessage.acknowledgementTypeCode).toEqual(acknowledgementTypeCode);
+    expect(parsedMessage.acknowledgementCode).toEqual(acknowledgementCode);
     expect(ACKNOWLEDGEMENT_TYPES.NEGATIVE).toContain(parsedMessage.acknowledgementTypeCode);
     expect(SERVICES.gp2gp).toEqual(parsedMessage.service);
   });
@@ -85,6 +89,7 @@ describe('parseCommonAcknowledgementFields', () => {
     const referencedMessageId = 'NOT FOUND';
     const acknowledgementDetail = 'NOT FOUND';
     const acknowledgementTypeCode = 'AA';
+    const acknowledgementCode = 'NOT FOUND';
 
     // when
     validateFieldsHaveSuccessfullyParsed.mockReturnValueOnce(undefined);
@@ -97,6 +102,7 @@ describe('parseCommonAcknowledgementFields', () => {
     expect(parsedMessage.referencedMessageId).toEqual(referencedMessageId);
     expect(parsedMessage.acknowledgementDetail).toEqual(acknowledgementDetail);
     expect(parsedMessage.acknowledgementTypeCode).toEqual(acknowledgementTypeCode);
+    expect(parsedMessage.acknowledgementCode).toEqual(acknowledgementCode);
     expect(ACKNOWLEDGEMENT_TYPES.POSITIVE).toContain(parsedMessage.acknowledgementTypeCode);
     expect(SERVICES.gp2gp).toEqual(parsedMessage.service);
   });

--- a/src/services/parser/acknowledgement-parser.js
+++ b/src/services/parser/acknowledgement-parser.js
@@ -23,6 +23,8 @@ export const parseAcknowledgementMessage = async message => {
       ? payloadContent['acknowledgement']['messageRef']['id']['root']
       : 'NOT FOUND',
     acknowledgementTypeCode: payloadContent?.['acknowledgement']?.['typeCode'],
+    acknowledgementCode: payloadContent?.['acknowledgement']?.['acknowledgementDetail']?.['code']?.['code'] ?
+    payloadContent['acknowledgement']['acknowledgementDetail']['code']['code'] : 'NOT FOUND',
     acknowledgementDetail: payloadContent?.['acknowledgement']?.['acknowledgementDetail']?.[
       'code'
     ]?.['displayName']

--- a/src/services/parser/acknowledgement-parser.js
+++ b/src/services/parser/acknowledgement-parser.js
@@ -24,12 +24,12 @@ export const parseAcknowledgementMessage = async message => {
       : 'NOT FOUND',
     acknowledgementTypeCode: payloadContent?.['acknowledgement']?.['typeCode'],
     acknowledgementCode: payloadContent?.['acknowledgement']?.['acknowledgementDetail']?.['code']?.['code'] ?
-    payloadContent['acknowledgement']['acknowledgementDetail']['code']['code'] : 'NOT FOUND',
+    payloadContent['acknowledgement']['acknowledgementDetail']['code']['code'] : undefined,
     acknowledgementDetail: payloadContent?.['acknowledgement']?.['acknowledgementDetail']?.[
       'code'
     ]?.['displayName']
       ? payloadContent['acknowledgement']['acknowledgementDetail']['code']['displayName']
-      : 'NOT FOUND'
+      : undefined
   };
 
   validateFieldsHaveSuccessfullyParsed(parsedFields);


### PR DESCRIPTION
* Removed deprecated Acknowledgement attributes from DynamoDB.
* Routed acknowledgement detail to `FailureReason` and `FailureCode` attributes.
* Updated unit and integration tests.