### PR TITLE
PRMP-620-fix

### DIFF
--- a/docker-compose-itest.yml
+++ b/docker-compose-itest.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 3000:3000
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:3.6.0
     ports:
       - 4566:4566
     environment:

--- a/docker-compose.localstack-local.yaml
+++ b/docker-compose.localstack-local.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   localstack:
     container_name: "localstack-ehr-out-service"
-    image: localstack/localstack
+    image: localstack/localstack:3.6.0
     network_mode: bridge
     ports:
       - "127.0.0.1:4566:4566"


### PR DESCRIPTION
pin localstack docker image version to 3.6.0 to resolve an issue on gocd pipeline