### PR TITLE
PRMP-1408 - ORC-OUT Global Secondary Index Delay

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -10,8 +10,8 @@ export const config = () => ({
   repositoryAsid: process.env.REPOSITORY_ASID,
   fragmentTransferRateLimitTimeoutMilliseconds:
     process.env.FRAGMENT_TRANSFER_RATE_LIMIT_TIMEOUT_MILLISECONDS || 0,
-  consumerApiKeys: loadConsumerKeys(),
-  dynamodbGsiWait: process.env.DYNAMODB_GSI_WAIT || 0
+  dynamodbGsiTimeoutMilliseconds: process.env.DYNAMODB_GSI_TIMEOUT_MILLISECONDS || 0,
+  consumerApiKeys: loadConsumerKeys()
 });
 
 const loadConsumerKeys = () => {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -11,7 +11,7 @@ export const config = () => ({
   fragmentTransferRateLimitTimeoutMilliseconds:
     process.env.FRAGMENT_TRANSFER_RATE_LIMIT_TIMEOUT_MILLISECONDS || 0,
   consumerApiKeys: loadConsumerKeys(),
-  dynamodbGsiWait: process.env.DYNAMODB_GSI_WAIT || 60000
+  dynamodbGsiWait: process.env.DYNAMODB_GSI_WAIT || 0
 });
 
 const loadConsumerKeys = () => {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -10,7 +10,8 @@ export const config = () => ({
   repositoryAsid: process.env.REPOSITORY_ASID,
   fragmentTransferRateLimitTimeoutMilliseconds:
     process.env.FRAGMENT_TRANSFER_RATE_LIMIT_TIMEOUT_MILLISECONDS || 0,
-  consumerApiKeys: loadConsumerKeys()
+  consumerApiKeys: loadConsumerKeys(),
+  dynamodbGsiWait: process.env.DYNAMODB_GSI_WAIT || 60000
 });
 
 const loadConsumerKeys = () => {

--- a/src/services/transfer/transfer-out-ehr-core.js
+++ b/src/services/transfer/transfer-out-ehr-core.js
@@ -37,7 +37,7 @@ export async function transferOutEhrCore({
   try {
     if (await isEhrRequestDuplicate(outboundConversationId)) return;
     await createOutboundConversation(outboundConversationId, nhsNumber, odsCode);
-    await sleep(config.dynamodbGsiWait);
+    await sleep(config.dynamodbGsiTimeoutMilliseconds);
     if (!(await patientAndPracticeOdsCodesMatch(nhsNumber, odsCode))) {
       // TODO PRMP-523 when implementing this NACK - I do not think we should update the conversation status here
       await updateConversationStatus(

--- a/src/services/transfer/transfer-out-ehr-core.js
+++ b/src/services/transfer/transfer-out-ehr-core.js
@@ -7,6 +7,7 @@ import {
 import { logError, logInfo, logWarning } from '../../middleware/logging';
 import { getEhrCoreAndFragmentIdsFromRepo } from '../ehr-repo/get-ehr';
 import { setCurrentSpanAttributes } from '../../config/tracing';
+import { config } from '../../config';
 import { parseMessageId } from '../parser/parsing-utilities';
 import { sendCore } from '../gp2gp/send-core';
 import {
@@ -36,7 +37,7 @@ export async function transferOutEhrCore({
   try {
     if (await isEhrRequestDuplicate(outboundConversationId)) return;
     await createOutboundConversation(outboundConversationId, nhsNumber, odsCode);
-
+    await sleep(config.dynamodbGsiWait);
     if (!(await patientAndPracticeOdsCodesMatch(nhsNumber, odsCode))) {
       // TODO PRMP-523 when implementing this NACK - I do not think we should update the conversation status here
       await updateConversationStatus(
@@ -173,3 +174,7 @@ const handleCoreTransferError = async (
       });
   }
 };
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/terraform/ecs_task.tf
+++ b/terraform/ecs_task.tf
@@ -211,6 +211,6 @@ data "aws_ssm_parameter" "dynamodb_prefix_list_id" {
   name = "/repo/${var.environment}/output/prm-deductions-infra/dynamodb_prefix_list_id"
 }
 
-data "aws_ssm_parameter" "dynamodb_gsi_wait" {
-  name = "/repo/${var.environment}/output/prm-repo-ehr-out-service/dynamodb_gsi_wait"
+data "aws_ssm_parameter" "dynamodb_gsi_timeout_milliseconds" {
+  name = "/repo/${var.environment}/output/prm-repo-ehr-out-service/dynamodb_gsi_timeout_milliseconds"
 }

--- a/terraform/ecs_task.tf
+++ b/terraform/ecs_task.tf
@@ -24,7 +24,7 @@ locals {
     { name = "SQS_EHR_OUT_INCOMING_QUEUE_URL", value = aws_sqs_queue.service_incoming.id },
     { name = "FRAGMENT_TRANSFER_RATE_LIMIT_TIMEOUT_MILLISECONDS", value = "100" },
     { name = "DYNAMODB_NAME", value = data.aws_ssm_parameter.dynamodb_name.value },
-    { name = "DYNAMODB_GSI_WAIT", value = data.aws_ssm_parameter.dynamodb_gsi_wait.value }
+    { name = "DYNAMODB_GSI_TIMEOUT_MILLISECONDS", value = data.aws_ssm_parameter.dynamodb_gsi_timeout_milliseconds.value }
   ]
   secret_environment_variables = [
     { name      = "GP2GP_MESSENGER_AUTHORIZATION_KEYS",

--- a/terraform/ecs_task.tf
+++ b/terraform/ecs_task.tf
@@ -23,7 +23,8 @@ locals {
     { name = "LOG_LEVEL", value = var.log_level },
     { name = "SQS_EHR_OUT_INCOMING_QUEUE_URL", value = aws_sqs_queue.service_incoming.id },
     { name = "FRAGMENT_TRANSFER_RATE_LIMIT_TIMEOUT_MILLISECONDS", value = "100" },
-    { name = "DYNAMODB_NAME", value = data.aws_ssm_parameter.dynamodb_name.value }
+    { name = "DYNAMODB_NAME", value = data.aws_ssm_parameter.dynamodb_name.value },
+    { name = "DYNAMODB_GSI_WAIT", value = data.aws_ssm_parameter.dynamodb_gsi_wait.value }
   ]
   secret_environment_variables = [
     { name      = "GP2GP_MESSENGER_AUTHORIZATION_KEYS",
@@ -208,4 +209,8 @@ data "aws_ssm_parameter" "service-to-ehr-repo-sg-id" {
 
 data "aws_ssm_parameter" "dynamodb_prefix_list_id" {
   name = "/repo/${var.environment}/output/prm-deductions-infra/dynamodb_prefix_list_id"
+}
+
+data "aws_ssm_parameter" "dynamodb_gsi_wait" {
+  name = "/repo/${var.environment}/output/prm-repo-ehr-out-service/dynamodb_gsi_wait"
 }


### PR DESCRIPTION
NOTE: The SSM parameter `/repo/dev/output/prm-repo-ehr-out-service/dynamodb_gsi_timeout_milliseconds` will need to be created manually on each environment prior to merge/deployment (may need adding to runbook?)